### PR TITLE
transient track parameters and covariance matrix from regression

### DIFF
--- a/TrackingTools/TransientTrack/interface/GsfTransientTrack.h
+++ b/TrackingTools/TransientTrack/interface/GsfTransientTrack.h
@@ -35,6 +35,8 @@ namespace reco {
 
     GsfTransientTrack( const GsfTrackRef & tk , const MagneticField* field, const edm::ESHandle<GlobalTrackingGeometry>& trackingGeometry, 
 		       const math::XYZVector& momVal, const int chVal);
+    GsfTransientTrack( const GsfTrackRef & tk , const MagneticField* field, const edm::ESHandle<GlobalTrackingGeometry>& trackingGeometry,
+                       const math::XYZVector& momVal, const int chVal, const float regERatio);
 
     GsfTransientTrack( const GsfTransientTrack & tt );
     

--- a/TrackingTools/TransientTrack/interface/TransientTrackBuilder.h
+++ b/TrackingTools/TransientTrack/interface/TransientTrackBuilder.h
@@ -31,6 +31,7 @@ class TransientTrackBuilder {
     reco::TransientTrack build ( const reco::GsfTrackRef & p)  const;
 
     reco::TransientTrack buildfromGSF ( const reco::GsfTrackRef & p) const;
+    reco::TransientTrack buildfromReg ( const reco::GsfTrackRef & p, const math::XYZVector & regMomentum, const float & regERatio) const;
 
     reco::TransientTrack build ( const reco::CandidatePtr * p)  const;
     reco::TransientTrack build ( const reco::CandidatePtr & p)  const;

--- a/TrackingTools/TransientTrack/src/GsfTransientTrack.cc
+++ b/TrackingTools/TransientTrack/src/GsfTransientTrack.cc
@@ -125,6 +125,7 @@ GsfTransientTrack::GsfTransientTrack( const GsfTrackRef & tk , const double time
   initialFTS = trajectoryStateTransform::initialFreeState(*tk, field);
 }
 
+//from gsfMode
 GsfTransientTrack::GsfTransientTrack( const GsfTrackRef & tk , const MagneticField* field,
 				      const edm::ESHandle<GlobalTrackingGeometry>& tg, 
 				      const math::XYZVector& momVal, const int chVal):
@@ -149,6 +150,45 @@ GsfTransientTrack::GsfTransientTrack( const GsfTrackRef & tk , const MagneticFie
   for (unsigned int iv1 = 0; iv1 < 5; ++iv1) {
     if(iv1 < reco::GsfTrack::dimensionMode) covErr(iv1, iv1) = covMode(iv1, iv1);
     else covErr(iv1, iv1) = covMean(iv1, iv1);
+  }
+  for (unsigned int iv1 = 0; iv1 < 5; ++iv1) {
+    for (unsigned int iv2 = 0; iv2 < iv1; ++iv2) {
+      double cov12 = covMean(iv1, iv2) * sqrt(covErr(iv1, iv1) / covMean(iv1, iv1) *
+					      covErr(iv2, iv2) / covMean(iv2, iv2));
+      covErr(iv1, iv2) = covErr(iv2, iv1) = cov12;
+    }
+  }
+
+  CurvilinearTrajectoryError err(covErr);
+  initialFTS = FreeTrajectoryState( par, err);
+}
+
+//from regression
+GsfTransientTrack::GsfTransientTrack( const GsfTrackRef & tk , const MagneticField* field,
+				      const edm::ESHandle<GlobalTrackingGeometry>& tg,
+				      const math::XYZVector& momVal, const int chVal, const float regERatio):
+  GsfTrack(*tk),
+  tkr_(), hasTime(false), timeExt_(0.), dtErrorExt_(0.),
+  theField(field), initialTSOSAvailable(false),
+  initialTSCPAvailable(false), blStateAvailable(false), theTrackingGeometry(tg),
+  theTIPExtrapolator(AnalyticalPropagator(field, alongMomentum)){
+
+  Basic3DVector<float> pos (tk->referencePoint());
+  GlobalPoint gpos(pos);
+  Basic3DVector<float> mom (momVal);
+  GlobalVector gmom( mom);
+  TrackCharge tkCh(chVal);
+  GlobalTrajectoryParameters par( gpos, gmom, TrackCharge(tkCh), field);
+
+  //from RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
+  reco::GsfTrack::CovarianceMatrixMode covMode = tk->covarianceMode();
+  reco::TrackBase::CovarianceMatrix covMean = tk->covariance();
+
+  AlgebraicSymMatrix55 covErr;
+  for (unsigned int iv1 = 0; iv1 < 5; ++iv1) {
+    if(iv1 < reco::GsfTrack::dimensionMode) covErr(iv1, iv1) = covMode(iv1, iv1);
+    else covErr(iv1, iv1) = covMean(iv1, iv1);
+    if(iv1 == 0) covErr(iv1, iv1) = covErr(iv1, iv1) * regERatio * regERatio;
   }
   for (unsigned int iv1 = 0; iv1 < 5; ++iv1) {
     for (unsigned int iv2 = 0; iv2 < iv1; ++iv2) {

--- a/TrackingTools/TransientTrack/src/TransientTrackBuilder.cc
+++ b/TrackingTools/TransientTrack/src/TransientTrackBuilder.cc
@@ -69,6 +69,9 @@ TransientTrack TransientTrackBuilder::buildfromGSF (const GsfTrackRef & t) const
   return TransientTrack(new GsfTransientTrack(t, theField, theTrackingGeometry, math::XYZVector(t->momentumMode()), t->chargeMode()));
 };
 
+TransientTrack TransientTrackBuilder::buildfromReg ( const reco::GsfTrackRef & t, const math::XYZVector & regMomentum, const float & regERatio) const {
+  return TransientTrack(new GsfTransientTrack(t, theField, theTrackingGeometry, regMomentum, t->chargeMode(), regERatio));
+};
 
 vector<TransientTrack> 
 TransientTrackBuilder::build ( const edm::Handle<reco::TrackCollection> & trkColl) const


### PR DESCRIPTION
Transient track builder from gsfTrack,  using momentum and momentum_error in the covariance matrix from inputs
This PR is needed for https://github.com/CMSBParking/BParkingNANO/pull/91